### PR TITLE
Updated redirect URIs to match new Spotify URI Rules from 9th of April 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Compila i campi:
 
 > **🔑 CRUCIALE**: Aggiungi ESATTAMENTE questi due URI:
 
-1. `http://localhost:5000/api/auth/source/callback`
-2. `http://localhost:5000/api/auth/destination/callback`
+1. `http://[::1]:5000/api/auth/source/callback`
+2. `http://[::1]:5000/api/auth/destination/callback`
 
 #### **2.4 Ottieni le Credenziali**
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Compila i campi:
 |-------|--------|
 | **App name** | `Spotify Migration Tool` |
 | **App description** | `Tool per migrare playlist tra account Spotify` |
-| **Website** | `http://localhost:5000` |
+| **Website** | `http://[::1]:5000` |
 | **Redirect URI** | Vedi sotto ⬇️ |
 
 #### **2.3 Aggiungi i Redirect URI** 
@@ -169,8 +169,8 @@ SPOTIFY_CLIENT_ID=il_tuo_client_id
 SPOTIFY_CLIENT_SECRET=il_tuo_client_secret
 
 # NON modificare questi
-SPOTIFY_REDIRECT_URI=http://localhost:5000/api/auth/source/callback
-DEST_REDIRECT_URI=http://localhost:5000/api/auth/destination/callback
+SPOTIFY_REDIRECT_URI=http://[::1]:5000/api/auth/source/callback
+DEST_REDIRECT_URI=http://[::1]:5000/api/auth/destination/callback
 
 # Genera una stringa casuale lunga
 SESSION_SECRET=stringa_casuale_molto_lunga_e_sicura
@@ -190,10 +190,10 @@ npm start
 ```
 🚀 Server avviato su porta 5000
 🎵 Spotify Migration Tool pronto!
-🌐 Apri: http://localhost:5000
+🌐 Apri: http://[::1]:5000
 ```
 
-**Apri il browser su:** http://localhost:5000
+**Apri il browser su:** http://[::1]:5000
 
 ---
 
@@ -261,8 +261,8 @@ Durante la migrazione vedrai aggiornamenti in tempo reale:
 **❌ "INVALID_CLIENT: Invalid redirect URI"**
 - **Problema**: Redirect URI non configurati correttamente
 - **Soluzione**: Verifica che nell'app Spotify ci siano ESATTAMENTE:
-  - `http://localhost:5000/api/auth/source/callback`
-  - `http://localhost:5000/api/auth/destination/callback`
+  - `http://[::1]:5000/api/auth/source/callback`
+  - `http://[::1]:5000/api/auth/destination/callback`
 
 **❌ "403 Forbidden" durante l'autenticazione**
 - **Problema**: Account non aggiunto come utente di test

--- a/config-example.env
+++ b/config-example.env
@@ -19,10 +19,10 @@ SPOTIFY_CLIENT_SECRET=inserisci_qui_il_tuo_client_secret
 # nella tua app Spotify Developer Dashboard
 
 # URI per l'account sorgente (da cui copi i dati)
-SPOTIFY_REDIRECT_URI=http://localhost:5000/api/auth/source/callback
+SPOTIFY_REDIRECT_URI=http://[::1]:5000/api/auth/source/callback
 
 # URI per l'account destinazione (dove copi i dati)
-DEST_REDIRECT_URI=http://localhost:5000/api/auth/destination/callback
+DEST_REDIRECT_URI=http://[::1]:5000/api/auth/destination/callback
 
 
 # 🔒 SICUREZZA SESSIONE (OBBLIGATORIO)


### PR DESCRIPTION
Updated redirect URIs since Spotify _won't_ allow to use **http://localhost:XXXX** anymore as a redirection URI for security reasons

Both **http://[::1]:XXXX** and **http://127.0.0.1:XXXX** are valid to replace localhost, so feel free to change it to the one you prefer

config-example.env updated to this change
README.MD also updated to match this change on setup instructions 